### PR TITLE
Add compatibility with pull request events

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -136,4 +136,18 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        git checkout --progress --force -B "${{ github.ref_name }}" "${{ github.ref }}"
+
+        # Compatibility with pull request triggers
+        if [[ -n "${{ github.head_ref }}" ]] ; then
+          export ref="refs/heads/${{ github.head_ref }}"
+          export ref_name="${{ github.head_ref }}"
+        else
+          export ref="${{ github.ref }}"
+          export ref_name="${{ github.ref_name }}"
+        fi
+
+        if [[ "${{ github.ref_type }}" == 'tag' ]] ; then
+          git checkout --progress --force "${ref}"
+        else
+          git checkout --progress --force -B "${ref_name}" "${ref}"
+        fi


### PR DESCRIPTION
Despite the docs saying otherwise, there is a situation where `ref` can be a GitHub specific type: `refs/pull/PR_NUMBER/merge`