### PR TITLE
Fix path env variable for windows runners

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,7 @@ runs:
         CHECKOUT: ${{ inputs.checkout }}
         DIRECTION: ${{ inputs.direction }}
         NAME: ${{ inputs.name }}
-        PATH: ${{ inputs.path }}
+        PATHH: ${{ inputs.path }}
         LFS: ${{ inputs.checkout-lfs }}
       run: |
         set -euo pipefail
@@ -87,7 +87,7 @@ runs:
           fi
         fi
 
-        echo "Path env Value: ${PATH}"
+        echo "Path env Value: ${PATHH}"
 
         if [[ -n "${PATH:-}" ]] ; then
           echo "::set-output name=path::${PATH}"

--- a/action.yaml
+++ b/action.yaml
@@ -87,6 +87,8 @@ runs:
           fi
         fi
 
+        echo "Path env Value: ${PATH}"
+
         if [[ -n "${PATH:-}" ]] ; then
           echo "::set-output name=path::${PATH}"
         else

--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,7 @@ runs:
         CHECKOUT: ${{ inputs.checkout }}
         DIRECTION: ${{ inputs.direction }}
         NAME: ${{ inputs.name }}
-        NEW_PATH: ${{ inputs.path }}
+        DIR_PATH: ${{ inputs.path }}
         LFS: ${{ inputs.checkout-lfs }}
       run: |
         set -euo pipefail
@@ -87,10 +87,8 @@ runs:
           fi
         fi
 
-        echo "Path env Value: ${NEW_PATH}"
-
-        if [[ -n "${NEW_PATH:-}" ]] ; then
-          echo "::set-output name=path::${NEW_PATH}"
+        if [[ -n "${DIR_PATH:-}" ]] ; then
+          echo "::set-output name=path::${DIR_PATH}"
         else
           if [[ "${CHECKOUT}" == 'true' ]] ; then
             echo "::set-output name=path::./.git/"

--- a/action.yaml
+++ b/action.yaml
@@ -56,7 +56,7 @@ runs:
         CHECKOUT: ${{ inputs.checkout }}
         DIRECTION: ${{ inputs.direction }}
         NAME: ${{ inputs.name }}
-        PATHH: ${{ inputs.path }}
+        NEW_PATH: ${{ inputs.path }}
         LFS: ${{ inputs.checkout-lfs }}
       run: |
         set -euo pipefail
@@ -87,10 +87,10 @@ runs:
           fi
         fi
 
-        echo "Path env Value: ${PATHH}"
+        echo "Path env Value: ${NEW_PATH}"
 
-        if [[ -n "${PATH:-}" ]] ; then
-          echo "::set-output name=path::${PATH}"
+        if [[ -n "${NEW_PATH:-}" ]] ; then
+          echo "::set-output name=path::${NEW_PATH}"
         else
           if [[ "${CHECKOUT}" == 'true' ]] ; then
             echo "::set-output name=path::./.git/"


### PR DESCRIPTION
It seems that in trying to set the `PATH` env variable in the `action.yml` clashed with the variable that already existed in the Windows OS, resulting in a malformed value.

This PR is simply a rename of that variable to prevent a clash.